### PR TITLE
Corrals diagnostics

### DIFF
--- a/flow.xcodeproj/project.pbxproj
+++ b/flow.xcodeproj/project.pbxproj
@@ -32,6 +32,11 @@
 		99C1939C29F5774600C3F53F /* instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 99C1939A29F5774600C3F53F /* instance.hpp */; };
 		99C1939F29F5819A00C3F53F /* utility.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 99C1939D29F5819A00C3F53F /* utility.cpp */; };
 		99C193A029F5819A00C3F53F /* utility.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 99C1939E29F5819A00C3F53F /* utility.hpp */; };
+		99C193A229F6EB4B00C3F53F /* expected.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 99C193A129F6EB4B00C3F53F /* expected.hpp */; };
+		99C193A529F76AB800C3F53F /* descriptor_iostream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 99C193A329F76AB800C3F53F /* descriptor_iostream.cpp */; };
+		99C193A629F76AB800C3F53F /* descriptor_iostream.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 99C193A429F76AB800C3F53F /* descriptor_iostream.hpp */; };
+		99C193B029F7AFD100C3F53F /* fstream.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 99C193AF29F7AFD100C3F53F /* fstream.hpp */; };
+		99C193B229F7AFF300C3F53F /* fstream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 99C193B129F7AFF300C3F53F /* fstream.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -93,6 +98,11 @@
 		99C1939A29F5774600C3F53F /* instance.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = instance.hpp; sourceTree = "<group>"; };
 		99C1939D29F5819A00C3F53F /* utility.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = utility.cpp; sourceTree = "<group>"; };
 		99C1939E29F5819A00C3F53F /* utility.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = utility.hpp; sourceTree = "<group>"; };
+		99C193A129F6EB4B00C3F53F /* expected.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = expected.hpp; sourceTree = "<group>"; };
+		99C193A329F76AB800C3F53F /* descriptor_iostream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = descriptor_iostream.cpp; sourceTree = "<group>"; };
+		99C193A429F76AB800C3F53F /* descriptor_iostream.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = descriptor_iostream.hpp; sourceTree = "<group>"; };
+		99C193AF29F7AFD100C3F53F /* fstream.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fstream.hpp; sourceTree = "<group>"; };
+		99C193B129F7AFF300C3F53F /* fstream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fstream.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -179,7 +189,10 @@
 				99C1938E29F50EFD00C3F53F /* channel.hpp */,
 				99C1939229F511B700C3F53F /* connection.hpp */,
 				99940BF629F1DAE800A77461 /* descriptor_id.hpp */,
+				99C193A429F76AB800C3F53F /* descriptor_iostream.hpp */,
+				99C193A129F6EB4B00C3F53F /* expected.hpp */,
 				99C1938229F506C200C3F53F /* file_port.hpp */,
+				99C193AF29F7AFD100C3F53F /* fstream.hpp */,
 				99C1939A29F5774600C3F53F /* instance.hpp */,
 				99940BED29F1C9A500A77461 /* io_type.hpp */,
 				99940BFA29F1F49F00A77461 /* process_id.hpp */,
@@ -197,7 +210,9 @@
 				99C1938D29F50EFD00C3F53F /* channel.cpp */,
 				99C1939129F511B700C3F53F /* connection.cpp */,
 				99940BF529F1DAE800A77461 /* descriptor_id.cpp */,
+				99C193A329F76AB800C3F53F /* descriptor_iostream.cpp */,
 				99C1938129F506C200C3F53F /* file_port.cpp */,
+				99C193B129F7AFF300C3F53F /* fstream.cpp */,
 				99C1939929F5774600C3F53F /* instance.cpp */,
 				99940BEC29F1C9A500A77461 /* io_type.cpp */,
 				99940BF929F1F49F00A77461 /* process_id.cpp */,
@@ -220,12 +235,15 @@
 				99C1939C29F5774600C3F53F /* instance.hpp in Headers */,
 				99940BF829F1DAE800A77461 /* descriptor_id.hpp in Headers */,
 				99C1939829F5136100C3F53F /* prototype.hpp in Headers */,
+				99C193A229F6EB4B00C3F53F /* expected.hpp in Headers */,
 				99940C0029F1F73900A77461 /* prototype_name.hpp in Headers */,
 				99C193A029F5819A00C3F53F /* utility.hpp in Headers */,
+				99C193B029F7AFD100C3F53F /* fstream.hpp in Headers */,
 				99C1939029F50EFD00C3F53F /* channel.hpp in Headers */,
 				99C1939429F511B700C3F53F /* connection.hpp in Headers */,
 				99940BFC29F1F49F00A77461 /* process_id.hpp in Headers */,
 				99C1937C29F4D70F00C3F53F /* prototype_port.hpp in Headers */,
+				99C193A629F76AB800C3F53F /* descriptor_iostream.hpp in Headers */,
 				99C1938429F506C200C3F53F /* file_port.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -322,12 +340,14 @@
 				99C1939329F511B700C3F53F /* connection.cpp in Sources */,
 				99C1938329F506C200C3F53F /* file_port.cpp in Sources */,
 				99940BFF29F1F73900A77461 /* prototype_name.cpp in Sources */,
+				99C193A529F76AB800C3F53F /* descriptor_iostream.cpp in Sources */,
 				99940BFB29F1F49F00A77461 /* process_id.cpp in Sources */,
 				99C1939729F5136100C3F53F /* prototype.cpp in Sources */,
 				99C1939B29F5774600C3F53F /* instance.cpp in Sources */,
 				99C1939F29F5819A00C3F53F /* utility.cpp in Sources */,
 				99C1937B29F4D70F00C3F53F /* prototype_port.cpp in Sources */,
 				99C1938F29F50EFD00C3F53F /* channel.cpp in Sources */,
+				99C193B229F7AFF300C3F53F /* fstream.cpp in Sources */,
 				99940BEE29F1C9A500A77461 /* io_type.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -346,7 +366,7 @@
 		99940BD229F1644400A77461 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
+				ALWAYS_SEARCH_USER_PATHS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -393,6 +413,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = /opt/homebrew/opt/boost/include/;
+				LIBRARY_SEARCH_PATHS = /opt/homebrew/opt/boost/lib/;
 				MACOSX_DEPLOYMENT_TARGET = 13.3;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -404,7 +426,7 @@
 		99940BD329F1644400A77461 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
+				ALWAYS_SEARCH_USER_PATHS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -445,6 +467,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = /opt/homebrew/opt/boost/include/;
+				LIBRARY_SEARCH_PATHS = /opt/homebrew/opt/boost/lib/;
 				MACOSX_DEPLOYMENT_TARGET = 13.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -477,7 +501,11 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				EXECUTABLE_PREFIX = lib;
-				HEADER_SEARCH_PATHS = ../../library/include;
+				HEADER_SEARCH_PATHS = (
+					../../library/include,
+					/opt/homebrew/opt/boost/include/,
+				);
+				OTHER_LDFLAGS = "-lboost_iostreams";
 				PRODUCT_NAME = flow;
 				SKIP_INSTALL = YES;
 			};
@@ -490,7 +518,11 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				EXECUTABLE_PREFIX = lib;
-				HEADER_SEARCH_PATHS = ../../library/include;
+				HEADER_SEARCH_PATHS = (
+					../../library/include,
+					/opt/homebrew/opt/boost/include/,
+				);
+				OTHER_LDFLAGS = "-lboost_iostreams";
 				PRODUCT_NAME = flow;
 				SKIP_INSTALL = YES;
 			};

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(Boost)
+
 file(GLOB FLOW_SRCS "source/flow/*.cpp")
 file(GLOB FLOW_HDRS "include/flow/*.hpp")
 
@@ -13,6 +15,10 @@ set(libsrc
 
 add_library(flow ${libsrc})
 add_library(flow::flow ALIAS flow)
+
+if(Boost_FOUND)
+	target_include_directories(flow SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
+endif()
 
 target_compile_features(flow PUBLIC cxx_std_20)
 set_target_properties(flow PROPERTIES

--- a/library/include/flow/descriptor_iostream.hpp
+++ b/library/include/flow/descriptor_iostream.hpp
@@ -1,0 +1,76 @@
+#ifndef dstream_hpp
+#define dstream_hpp
+
+#include <array>
+#include <cstddef> // for std::ptrdiff_t
+#include <iostream>
+#include <string> // fpr std::char_traits
+
+#include "flow/descriptor_id.hpp"
+
+namespace flow {
+
+/// @brief Descriptor stream buffer.
+/// @note Some of this class's implementation derives from Nicolai M. Josuttis handling for
+///   <code>boost::fdinbuf</code> and <code>boost::fdoutbuf</code>.
+/// @see http://www.josuttis.com/cppcode/fdstream.hpp.
+struct descriptor_streambuf: public std::streambuf {
+public:
+    using char_type = char;
+    using traits_type = std::char_traits<char_type>;
+    using int_type = typename traits_type::int_type;
+    using pos_type = typename traits_type::pos_type;
+    using off_type = typename traits_type::off_type;
+    using state_type = typename traits_type::state_type;
+
+    descriptor_streambuf(descriptor_id d): id(d)
+    {
+        // Intentionally empty.
+    }
+
+protected:
+    int_type underflow() override;
+    int_type overflow(int_type c = traits_type::eof()) override;
+    std::streamsize xsputn(const char_type* s, std::streamsize n) override;
+    // TODO: override sync()
+
+private:
+    static constexpr auto buffer_size = 1024u;
+    static constexpr auto putback_size = std::ptrdiff_t{8};
+    descriptor_id id{invalid_descriptor_id};
+    std::array<char, buffer_size> buffer{};
+};
+
+struct descriptor_istream: public std::istream {
+    descriptor_istream(descriptor_id fd)
+        : std::istream(nullptr), streambuf(fd)
+    {
+        rdbuf(&streambuf);
+    }
+private:
+    descriptor_streambuf streambuf;
+};
+
+struct descriptor_ostream: public std::ostream {
+    descriptor_ostream(descriptor_id fd)
+        : std::ostream(nullptr), streambuf(fd)
+    {
+        rdbuf(&streambuf);
+    }
+private:
+    descriptor_streambuf streambuf;
+};
+
+struct descriptor_iostream: public std::iostream {
+    descriptor_iostream(descriptor_id fd)
+        : std::iostream(nullptr), streambuf(fd)
+    {
+        rdbuf(&streambuf);
+    }
+private:
+    descriptor_streambuf streambuf;
+};
+
+}
+
+#endif /* dstream_hpp */

--- a/library/include/flow/expected.hpp
+++ b/library/include/flow/expected.hpp
@@ -1,0 +1,122 @@
+#ifndef expected_h
+#define expected_h
+
+#if !defined(__has_include) || !__has_include(<expected>)
+
+#include <initializer_list>
+#include <variant>
+#include <type_traits> // for std::is_convertible_v
+#include <utility> // for std::in_place_t
+
+namespace flow {
+
+template<class E>
+class unexpected {
+public:
+    constexpr unexpected() = default;
+
+    constexpr unexpected(const unexpected&) = default;
+
+    constexpr unexpected(unexpected&&)
+        noexcept(noexcept(std::is_nothrow_move_constructible_v<E>)) = default;
+
+    template<class Err = E, class X = std::enable_if_t<
+        !std::is_same_v<std::remove_cvref_t<Err>, unexpected> &&
+        std::is_constructible_v<E, Err>, E>>
+    constexpr explicit unexpected(Err&& err): val{std::forward<Err>(err)}
+    {
+        // Intentionally empty.
+    }
+
+    constexpr unexpected& operator=(const unexpected&) = default;
+
+    constexpr unexpected& operator=(unexpected&&)
+        noexcept(noexcept(std::is_nothrow_move_constructible_v<E>)) = default;
+
+    constexpr const E& value() const& noexcept
+    {
+        return val;
+    }
+
+    constexpr E& value() & noexcept
+    {
+        return val;
+    }
+
+    constexpr const E&& value() const&& noexcept
+    {
+        return val;
+    }
+
+    constexpr E&& value() && noexcept
+    {
+        return val;
+    }
+
+    template<class E2>
+    friend constexpr bool
+    operator==(const unexpected&, const unexpected<E2>&);
+
+private:
+    E val;
+};
+
+/// @brief An implementation of <code>std::expected</code> for C++20.
+/// @see https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0323r11.html
+template <class T, class E>
+class expected {
+public:
+    using value_type = T;
+    using error_type = E;
+    using unexpected_type = unexpected<E>;
+
+    static_assert(std::is_default_constructible_v<T>);
+
+    constexpr expected() = default;
+
+    template<class U = T, class X = std::enable_if_t<
+        !std::is_same_v<std::remove_cvref_t<U>, expected> &&
+        std::is_constructible_v<T, U>, E>>
+    constexpr explicit(!std::is_convertible_v<U, T>) expected(U&& v):
+        value{std::forward<U>(v)}
+    {
+        // Intentionally empty.
+    }
+
+    template<class G>
+    constexpr expected(const unexpected<G>& error):
+        value{error.value()}
+    {
+        // Intentionall empty.
+    }
+
+    template<class G>
+    constexpr expected(unexpected<G>&& other):
+        value{std::move(other.value())}
+    {
+        // Intentionally empty.
+    }
+
+    constexpr bool has_value() const noexcept
+    {
+        return value.index() == 0u;
+    }
+
+private:
+    std::variant<T, E> value{T{}};
+};
+
+}
+
+#else // presumably compiler supporting C++23
+
+#include <expected>
+
+namespace flow {
+using std::unexpected;
+using std::expected;
+}
+
+#endif
+
+#endif /* expected_h */

--- a/library/include/flow/fstream.hpp
+++ b/library/include/flow/fstream.hpp
@@ -1,0 +1,741 @@
+#ifndef fstream_hpp
+#define fstream_hpp
+
+#include <cassert>
+#include <cstdint> // for std::uint32_t
+#include <cstdio> // for FILE*
+#include <cstring> // for std::strlen, std::memmove
+#include <iostream>
+#include <limits> // for std::numeric_limits
+#include <streambuf>
+#include <string>
+#include <filesystem>
+#include <type_traits> // for std::make_unsigned_t
+#include <utility> // for std::exchange
+
+#include "flow/descriptor_id.hpp"
+
+namespace flow {
+
+/// @brief File based I/O stream class.
+/// @note This supports C++23's <code>noreplace</code> and a new <code>tmpfile</code>
+///   openmode. The latter results in the stream being opened for reading/writing to a temporary file that
+///   either never shows up in the file system, or is deleted from it right after its creation. One has to use
+///   the open modes however from this class; not from <code>std::ios_base</code> or any derived
+///   classes of that other than this class.
+/// @note This class's implementation derives from LLVM's handling for
+///   <code>std::fstream</code>, <code>std::__stdinbuf</code>, and <code>__stdoutbuf</code>
+///   sans support for locales.
+/// @see https://github.com/llvm/llvm-project/blob/main/libcxx/src/std_stream.h.
+/// @see https://github.com/llvm/llvm-project/blob/main/libcxx/include/fstream.
+struct fstream: public std::iostream {
+
+    /// @brief Open mode.
+    using openmode = std::uint32_t;
+
+    static constexpr auto app       = openmode{0x01};
+    static constexpr auto binary    = openmode{0x02};
+    static constexpr auto in        = openmode{0x04};
+    static constexpr auto out       = openmode{0x08};
+    static constexpr auto trunc     = openmode{0x10};
+    static constexpr auto ate       = openmode{0x20};
+
+    /// @brief No-replace - provides exclusive file creation.
+    /// @note Support C++23's <code>noreplace</code> open mode.
+    /// @see https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2467r1.html
+    static constexpr auto noreplace = openmode{0x40};
+
+    /// @brief Temporary file.
+    /// @note This is potentially a proposed new openmode by me!
+    static constexpr auto tmpfile = openmode{0x80};
+
+    static constexpr auto to_fopen_mode(openmode value) -> const char*;
+
+    struct filebuf: public std::streambuf {
+        filebuf();
+        filebuf(const filebuf& other) = delete;
+        filebuf(filebuf&& other) noexcept;
+        ~filebuf() override;
+        auto operator=(const filebuf& other) -> filebuf& = delete;
+        auto operator=(filebuf&& other) noexcept -> filebuf&;
+        auto swap(filebuf& rhs) -> void;
+        auto is_open() const noexcept -> bool;
+        auto open(FILE* new_fp, openmode mode) noexcept -> filebuf*;
+        auto close() noexcept -> filebuf*;
+
+    private:
+        static constexpr auto default_buffer_size = 4096u;
+        static constexpr auto extbuf_min_size = 8u;
+
+        auto internal_setbuf(char_type* s, std::streamsize n) -> basic_streambuf<char_type, traits_type>*;
+        auto internal_sync() -> int;
+        auto internal_overflow(int_type c = traits_type::eof()) -> int_type;
+
+        /// @see https://en.cppreference.com/w/cpp/io/basic_streambuf/underflow.
+        auto underflow() -> int_type override;
+
+        /// @see https://en.cppreference.com/w/cpp/io/basic_streambuf/uflow.
+        //int_type uflow() override;
+
+        /// @see https://en.cppreference.com/w/cpp/io/basic_streambuf/pbackfail.
+        auto pbackfail(int_type c = traits_type::eof()) -> int_type override;
+
+        /// @see https://en.cppreference.com/w/cpp/io/basic_streambuf/overflow.
+        auto overflow(int_type c = traits_type::eof()) -> int_type override;
+
+        auto setbuf(char_type* s, std::streamsize n) -> basic_streambuf<char_type, traits_type>* override;
+
+        /// @see https://en.cppreference.com/w/cpp/io/basic_streambuf/sputn.
+        auto xsputn(const char* s, std::streamsize n) -> std::streamsize override;
+
+        /// @see https://en.cppreference.com/w/cpp/io/basic_streambuf/pubseekoff.
+        auto seekoff(off_type off, seekdir way,
+                     std::ios_base::openmode wch = std::ios_base::in|std::ios_base::out) -> pos_type override;
+
+        /// @see https://en.cppreference.com/w/cpp/io/basic_streambuf/pubseekpos.
+        auto seekpos(pos_type sp,
+                     std::ios_base::openmode wch = std::ios_base::in|std::ios_base::out) -> pos_type override;
+
+        /// @see https://en.cppreference.com/w/cpp/io/basic_streambuf/pubsync.
+        auto sync() -> int override;
+
+        auto read_mode() -> bool;
+        auto write_mode() -> void;
+
+        char* extbuf_{};
+        const char* extbufnext_{};
+        const char* extbufend_{};
+        char extbuf_min_[extbuf_min_size]{};
+        size_t ebs_{};
+        char_type* intbuf_{};
+        size_t ibs_{};
+        FILE *fp{};
+        openmode opened_mode{};
+        openmode iomode{};
+        bool owns_eb_{};
+        bool owns_ib_{};
+    };
+
+    fstream();
+    fstream(const fstream& other) = delete;
+    fstream(fstream&& other) noexcept;
+
+    auto operator=(const fstream& other) noexcept -> fstream& = delete;
+    auto operator=(fstream&& other) noexcept -> fstream&;
+
+    auto is_open() const -> bool;
+    auto close() -> void;
+    auto open(FILE *fp, openmode mode) -> void;
+    auto open(descriptor_id id, openmode mode) -> void;
+    auto open(const char* filename, openmode mode = in|out) -> void;
+    auto open(const std::string& filename, openmode mode = in|out) -> void;
+    auto open(const std::filesystem::path& filename, openmode mode = in|out) -> void;
+
+private:
+    filebuf fb;
+};
+
+constexpr auto fstream::to_fopen_mode(openmode value) -> const char*
+{
+    switch (value) {
+    case out:
+    case out|trunc:
+        return "w";
+    case out|noreplace:
+    case out|trunc|noreplace:
+        return "wx";
+    case out|app:
+    case app:
+        return "a";
+    case in:
+        return "r";
+    case in|out:
+        return "r+";
+    case in|out|trunc:
+        return "w+";
+    case in|out|trunc|noreplace:
+        return "w+x";
+    case in|out|app:
+    case in|app:
+        return "a+";
+    case out|binary:
+    case out|trunc|binary:
+        return "wb";
+    case out|app|binary:
+    case app|binary:
+        return "ab";
+    case in|binary:
+        return "rb";
+    case in|out|binary:
+        return "r+b";
+    case in|out|trunc|binary:
+        return "w+b";
+    case in|out|trunc|binary|noreplace:
+        return "w+xb";
+    case in|out|app|binary:
+    case in|app|binary:
+        return "a+b";
+    }
+    return nullptr;
+}
+
+inline fstream::filebuf::filebuf()
+{
+    internal_setbuf(nullptr, default_buffer_size);
+}
+
+inline fstream::filebuf::filebuf(filebuf&& other) noexcept
+    : std::streambuf(other)
+{
+    if (other.extbuf_ == std::data(other.extbuf_min_))
+    {
+        extbuf_ = std::data(extbuf_min_);
+        extbufnext_ = extbuf_ + (other.extbufnext_ - other.extbuf_);
+        extbufend_ = extbuf_ + (other.extbufend_ - other.extbuf_);
+    }
+    else
+    {
+        extbuf_ = other.extbuf_;
+        extbufnext_ = other.extbufnext_;
+        extbufend_ = other.extbufend_;
+    }
+    ebs_ = other.ebs_;
+    intbuf_ = other.intbuf_;
+    ibs_ = other.ibs_;
+    fp = other.fp;
+    opened_mode = other.opened_mode;
+    iomode = other.iomode;
+    owns_eb_ = other.owns_eb_;
+    owns_ib_ = other.owns_ib_;
+    if (other.pbase())
+    {
+        if (other.pbase() == other.intbuf_) {
+            this->setp(intbuf_, intbuf_ + (other.epptr() - other.pbase()));
+        }
+        else {
+            this->setp((char_type*)extbuf_,
+                       (char_type*)extbuf_ + (other.epptr() - other.pbase()));
+        }
+        const auto diff = other.pptr() - other.pbase();
+        assert(std::abs(diff) < std::numeric_limits<int>::max());
+        this->pbump(static_cast<int>(diff));
+    }
+    else if (other.eback())
+    {
+        if (other.eback() == other.intbuf_) {
+            this->setg(intbuf_, intbuf_ + (other.gptr() - other.eback()),
+                       intbuf_ + (other.egptr() - other.eback()));
+        }
+        else {
+            this->setg((char_type*)extbuf_,
+                       (char_type*)extbuf_ + (other.gptr() - other.eback()),
+                       (char_type*)extbuf_ + (other.egptr() - other.eback()));
+        }
+    }
+    other.extbuf_ = nullptr;
+    other.extbufnext_ = nullptr;
+    other.extbufend_ = nullptr;
+    other.ebs_ = 0;
+    other.intbuf_ = nullptr;
+    other.ibs_ = 0;
+    other.fp = nullptr;
+    other.opened_mode = 0;
+    other.iomode = 0;
+    other.owns_eb_ = false;
+    other.owns_ib_ = false;
+    other.setg(nullptr, nullptr, nullptr);
+    other.setp(nullptr, nullptr);
+}
+
+inline fstream::filebuf::~filebuf()
+{
+    close();
+    if (owns_eb_) {
+        delete [] extbuf_;
+    }
+    if (owns_ib_) {
+        delete [] intbuf_;
+    }
+}
+
+inline auto fstream::filebuf::operator=(filebuf&& other) noexcept -> filebuf&
+{
+    close();
+    swap(other);
+    return *this;
+}
+
+inline auto fstream::filebuf::swap(filebuf& rhs) -> void
+{
+    basic_streambuf<char_type, traits_type>::swap(rhs);
+    if ((extbuf_ != std::data(extbuf_min_)) && (rhs.extbuf_ != std::data(rhs.extbuf_min_)))
+    {
+        // Neither *this nor rhs uses the small buffer, so we can simply swap the pointers.
+        std::swap(extbuf_, rhs.extbuf_);
+        std::swap(extbufnext_, rhs.extbufnext_);
+        std::swap(extbufend_, rhs.extbufend_);
+    }
+    else
+    {
+        const auto ln = extbufnext_       ? extbufnext_ - extbuf_             : 0;
+        const auto le = extbufend_        ? extbufend_ - extbuf_              : 0;
+        const auto rn = rhs.extbufnext_ ? rhs.extbufnext_ - rhs.extbuf_ : 0;
+        const auto re = rhs.extbufend_  ? rhs.extbufend_ - rhs.extbuf_  : 0;
+        if ((extbuf_ == std::data(extbuf_min_)) && (rhs.extbuf_ != std::data(rhs.extbuf_min_)))
+        {
+            // *this uses the small buffer, but rhs doesn't.
+            extbuf_ = rhs.extbuf_;
+            rhs.extbuf_ = std::data(rhs.extbuf_min_);
+            std::memmove(std::data(rhs.extbuf_min_), std::data(extbuf_min_), sizeof(extbuf_min_));
+        }
+        else if (extbuf_ != std::data(extbuf_min_) && rhs.extbuf_ == std::data(rhs.extbuf_min_))
+        {
+            // *this doesn't use the small buffer, but rhs does.
+            rhs.extbuf_ = extbuf_;
+            extbuf_ = std::data(extbuf_min_);
+            std::memmove(std::data(extbuf_min_), std::data(rhs.extbuf_min_), sizeof(extbuf_min_));
+        }
+        else
+        {
+            // Both *this and rhs use the small buffer.
+            char tmp[sizeof(extbuf_min_)];
+            std::memmove(std::data(tmp), std::data(extbuf_min_), sizeof(extbuf_min_));
+            std::memmove(std::data(extbuf_min_), std::data(rhs.extbuf_min_), sizeof(extbuf_min_));
+            std::memmove(std::data(rhs.extbuf_min_), std::data(tmp), sizeof(extbuf_min_));
+        }
+        extbufnext_ = extbuf_ + rn;
+        extbufend_ = extbuf_ + re;
+        rhs.extbufnext_ = rhs.extbuf_ + ln;
+        rhs.extbufend_ = rhs.extbuf_ + le;
+    }
+    std::swap(ebs_, rhs.ebs_);
+    std::swap(intbuf_, rhs.intbuf_);
+    std::swap(ibs_, rhs.ibs_);
+    std::swap(fp, rhs.fp);
+    std::swap(opened_mode, rhs.opened_mode);
+    std::swap(iomode, rhs.iomode);
+    std::swap(owns_eb_, rhs.owns_eb_);
+    std::swap(owns_ib_, rhs.owns_ib_);
+    if (this->eback() == (char_type*)rhs.extbuf_min_)
+    {
+        const auto n = this->gptr() - this->eback();
+        const auto e = this->egptr() - this->eback();
+        this->setg((char_type*)extbuf_min_,
+                   (char_type*)extbuf_min_ + n,
+                   (char_type*)extbuf_min_ + e);
+    }
+    else if (this->pbase() == (char_type*)rhs.extbuf_min_)
+    {
+        const auto n = this->pptr() - this->pbase();
+        const auto e = this->epptr() - this->pbase();
+        this->setp((char_type*)extbuf_min_,
+                   (char_type*)extbuf_min_ + e);
+        assert(n < static_cast<std::ptrdiff_t>(std::numeric_limits<int>::max()));
+        this->pbump(static_cast<int>(n));
+    }
+    if (rhs.eback() == (char_type*)extbuf_min_)
+    {
+        const auto n = rhs.gptr() - rhs.eback();
+        const auto e = rhs.egptr() - rhs.eback();
+        rhs.setg((char_type*)rhs.extbuf_min_,
+                   (char_type*)rhs.extbuf_min_ + n,
+                   (char_type*)rhs.extbuf_min_ + e);
+    }
+    else if (rhs.pbase() == (char_type*)extbuf_min_)
+    {
+        const auto n = rhs.pptr() - rhs.pbase();
+        const auto e = rhs.epptr() - rhs.pbase();
+        rhs.setp((char_type*)rhs.extbuf_min_,
+                   (char_type*)rhs.extbuf_min_ + e);
+        assert(n < static_cast<std::ptrdiff_t>(std::numeric_limits<int>::max()));
+        rhs.pbump(static_cast<int>(n));
+    }
+}
+
+inline void
+swap(fstream::filebuf& x, fstream::filebuf& y)
+{
+    x.swap(y);
+}
+
+inline auto fstream::filebuf::is_open() const noexcept -> bool
+{
+    return fp != nullptr;
+}
+
+inline auto fstream::filebuf::open(FILE* new_fp, openmode mode) noexcept -> filebuf*
+{
+    if (fp) {
+        return nullptr;
+    }
+    fp = new_fp;
+    if (!fp) {
+        return nullptr;
+    }
+    opened_mode = mode;
+    if (mode & ate) {
+        if (::fseek(fp, 0, SEEK_END) != 0) {
+            ::fclose(fp); // NOLINT(cppcoreguidelines-owning-memory)
+            fp = nullptr;
+            return nullptr;
+        }
+    }
+    return this;
+}
+
+inline auto fstream::filebuf::close() noexcept -> filebuf*
+{
+    if (!fp) {
+        return nullptr;
+    }
+    const auto sync_result = internal_sync();
+    const auto close_result = ::fclose(fp); // NOLINT(cppcoreguidelines-owning-memory)
+    if (sync_result || (close_result == EOF)) {
+        return nullptr;
+    }
+    opened_mode = 0;
+    fp = nullptr;
+    internal_setbuf(nullptr, 0);
+    return this;
+}
+
+inline auto fstream::filebuf::underflow() -> int_type
+{
+    if (!fp) {
+        return traits_type::eof();
+    }
+    const auto mode_changed = read_mode();
+    char_type char_buf{};
+    if (!this->gptr()) {
+        this->setg(&char_buf, &char_buf+1, &char_buf+1);
+    }
+    const size_t unget_sz = mode_changed ? 0 : std::min<size_t>((this->egptr() - this->eback()) / 2, 4);
+    int_type c = traits_type::eof();
+    if (this->gptr() == this->egptr())
+    {
+        std::memmove(this->eback(), this->egptr() - unget_sz, unget_sz * sizeof(char_type));
+        size_t nmemb = static_cast<size_t>(this->egptr() - this->eback() - unget_sz);
+        nmemb = ::fread(this->eback() + unget_sz, 1, nmemb, fp);
+        if (nmemb != 0)
+        {
+            this->setg(this->eback(),
+                       this->eback() + unget_sz,
+                       this->eback() + unget_sz + nmemb);
+            c = traits_type::to_int_type(*this->gptr());
+        }
+    }
+    else {
+        c = traits_type::to_int_type(*this->gptr());
+    }
+    if (this->eback() == &char_buf) {
+        this->setg(nullptr, nullptr, nullptr);
+    }
+    return c;
+}
+
+inline auto fstream::filebuf::pbackfail(int_type c) -> int_type
+{
+    if (fp && this->eback() < this->gptr())
+    {
+        if (traits_type::eq_int_type(c, traits_type::eof()))
+        {
+            this->gbump(-1);
+            return traits_type::not_eof(c);
+        }
+        if ((opened_mode & out) ||
+            traits_type::eq(traits_type::to_char_type(c), this->gptr()[-1]))
+        {
+            this->gbump(-1);
+            *this->gptr() = traits_type::to_char_type(c);
+            return c;
+        }
+    }
+    return traits_type::eof();
+}
+
+inline auto fstream::filebuf::internal_overflow(int_type c) -> int_type
+{
+    if (!fp) {
+        return traits_type::eof();
+    }
+    write_mode();
+    char_type char_buf{};
+    char_type* pb_save = this->pbase();
+    char_type* epb_save = this->epptr();
+    if (!traits_type::eq_int_type(c, traits_type::eof())) {
+        if (!pptr()) {
+            setp(&char_buf, &char_buf+1);
+        }
+        *pptr() = traits_type::to_char_type(c);
+        pbump(1);
+    }
+    if (pptr() != pbase()) {
+        const auto nmemb = static_cast<size_t>(this->pptr() - this->pbase());
+        if (std::fwrite(this->pbase(), sizeof(char_type), nmemb, fp) != nmemb) {
+            return traits_type::eof();
+        }
+        setp(pb_save, epb_save);
+    }
+    return traits_type::not_eof(c);
+}
+
+inline auto fstream::filebuf::overflow(int_type c) -> int_type
+{
+    return internal_overflow(c);
+}
+
+inline auto fstream::filebuf::internal_setbuf(char_type* s, std::streamsize n)
+    -> basic_streambuf<char_type, traits_type>*
+{
+    assert(n < std::numeric_limits<int>::max());
+    setg(nullptr, nullptr, nullptr);
+    setp(nullptr, nullptr);
+    if (owns_eb_) {
+        delete [] extbuf_;
+    }
+    if (owns_ib_) {
+        delete [] intbuf_;
+    }
+    ebs_ = n;
+    if (ebs_ > sizeof(extbuf_min_))
+    {
+        if (s) {
+            extbuf_ = (char*)s;
+            owns_eb_ = false;
+        }
+        else {
+            extbuf_ = new char[ebs_]; // NOLINT(cppcoreguidelines-owning-memory)
+            owns_eb_ = true;
+        }
+    }
+    else {
+        extbuf_ = std::data(extbuf_min_);
+        ebs_ = sizeof(extbuf_min_);
+        owns_eb_ = false;
+    }
+    ibs_ = 0;
+    intbuf_ = nullptr;
+    owns_ib_ = false;
+    return this;
+}
+
+inline auto fstream::filebuf::setbuf(char_type* s, std::streamsize n) -> basic_streambuf<char_type, traits_type>*
+{
+    return internal_setbuf(s, n);
+}
+
+inline auto fstream::filebuf::xsputn(const char* s, std::streamsize n) -> std::streamsize
+{
+    if (!(iomode & out))
+    {
+        setg(nullptr, nullptr, nullptr);
+        setp(nullptr, nullptr);
+        iomode = out;
+    }
+    assert(n >= 0);
+    return static_cast<std::streamsize>(std::fwrite(s, sizeof(char_type), static_cast<std::size_t>(n), fp));
+}
+
+inline auto fstream::filebuf::internal_sync() -> int
+{
+    if (!fp) {
+        return 0;
+    }
+    if (iomode & out)
+    {
+        if (pptr() != pbase()) {
+            if (internal_overflow() == traits_type::eof()) {
+                return -1;
+            }
+        }
+        if (std::fflush(fp)) {
+            return -1;
+        }
+    }
+    else if (iomode & in)
+    {
+        const auto c = egptr() - gptr();
+        if (::fseeko(fp, -c, SEEK_CUR)) {
+            return -1;
+        }
+        setg(nullptr, nullptr, nullptr);
+        iomode = 0;
+    }
+    return 0;
+}
+
+inline auto fstream::filebuf::sync() -> int
+{
+    return internal_sync();
+}
+
+inline auto
+fstream::filebuf::seekoff(off_type off, seekdir way, std::ios_base::openmode) -> pos_type
+{
+    if (!fp || sync()) {
+        return static_cast<pos_type>(static_cast<off_type>(-1));
+    }
+    int whence{};
+    switch (way)
+    {
+    case beg:
+        whence = SEEK_SET;
+        break;
+    case cur:
+        whence = SEEK_CUR;
+        break;
+    case end:
+        whence = SEEK_END;
+        break;
+    default:
+        return static_cast<pos_type>(static_cast<off_type>(-1));
+    }
+    if (::fseeko(fp, off, whence)) {
+        return static_cast<pos_type>(static_cast<off_type>(-1));
+    }
+    return ftello(fp);
+}
+
+inline auto
+fstream::filebuf::seekpos(pos_type sp, std::ios_base::openmode) -> pos_type
+{
+    if (!fp || sync()) {
+        return static_cast<pos_type>(static_cast<off_type>(-1));
+    }
+    if (::fseeko(fp, sp, SEEK_SET)) {
+        return static_cast<pos_type>(static_cast<off_type>(-1));
+    }
+    return sp;
+}
+
+inline auto fstream::filebuf::read_mode() -> bool
+{
+    if (!(iomode & in))
+    {
+        setp(nullptr, nullptr);
+        setg((char_type*)extbuf_,
+             (char_type*)extbuf_ + ebs_,
+             (char_type*)extbuf_ + ebs_);
+        iomode = in;
+        return true;
+    }
+    return false;
+}
+
+inline auto fstream::filebuf::write_mode() -> void
+{
+    if (!(iomode & out))
+    {
+        setg(nullptr, nullptr, nullptr);
+        if (ebs_ > sizeof(extbuf_min_)) {
+            setp((char_type*)extbuf_,
+                 (char_type*)extbuf_ + (ebs_ - 1));
+        }
+        else {
+            setp(nullptr, nullptr);
+        }
+        iomode = out;
+    }
+}
+
+inline fstream::fstream():
+    std::iostream{&fb}
+{
+    // Intentionally empty.
+}
+
+inline fstream::fstream(fstream&& other) noexcept:
+    std::iostream{std::move(other)}, fb{std::exchange(other.fb, filebuf{})}
+{
+    // Intentionally empty.
+}
+
+inline auto fstream::operator=(fstream&& other) noexcept -> fstream&
+{
+    std::iostream::operator=(std::move(other));
+    fb = std::move(other.fb); // NOLINT(bugprone-use-after-move)
+    return *this;
+}
+
+inline auto fstream::is_open() const -> bool
+{
+    return fb.is_open();
+}
+
+inline auto fstream::close() -> void
+{
+    if (!fb.close()) {
+        setstate(ios_base::failbit);
+    }
+}
+
+inline auto fstream::open(FILE *fp, openmode mode) -> void
+{
+    if (!fb.open(fp, mode)) {
+        setstate(ios_base::failbit);
+    }
+    else {
+        clear();
+    }
+}
+
+inline auto fstream::open(descriptor_id id, openmode mode) -> void
+{
+    if (const auto mode_cstr = to_fopen_mode(mode)) {
+        open(::fdopen(int(id), mode_cstr), mode);
+    }
+    else {
+        setstate(ios_base::failbit);
+    }
+}
+
+inline auto fstream::open(const char* filename, openmode mode) -> void
+{
+    if (mode & tmpfile) {
+        mode &= (~tmpfile);
+#if defined(O_TMPFILE)
+        // TODO: translate mode to Linux/POSIX open(2) flags plus O_TMPFILE!
+        const auto fd = ::open(filename, O_TMPFILE, 0666);
+#else
+        static constexpr auto buffer_size = std::size_t{1024u};
+        static constexpr char six_x[] = "XXXXXX";
+        char buffer[buffer_size];
+        const auto len = std::strlen(filename);
+        const auto last_char = (len > 0u)? filename[len - 1u]: '\0';
+        const auto separator = (last_char != '/')? "/": "";
+        const auto separator_len = std::strlen(separator);
+        const auto total_len = len + separator_len + std::size(six_x);
+        if (total_len >= buffer_size) {
+            setstate(ios_base::failbit);
+            return;
+        }
+        // Replace the following with the more readable std::format_to_n when available
+        std::copy_n(std::data(six_x), std::size(six_x),
+                    std::copy_n(separator, separator_len,
+                                std::copy_n(filename, len, std::data(buffer))));
+        const auto fd = ::mkstemp(std::data(buffer));
+#endif
+        open(descriptor_id(fd), mode);
+    }
+    else if (const auto mode_cstr = to_fopen_mode(mode)) {
+        open(::fopen(filename, mode_cstr), mode); // NOLINT(cppcoreguidelines-owning-memory)
+    }
+    else {
+        setstate(ios_base::failbit);
+    }
+}
+
+inline auto fstream::open(const std::string& filename, openmode mode) -> void
+{
+    open(filename.c_str(), mode);
+}
+
+inline auto fstream::open(const std::filesystem::path& filename,
+                          openmode mode) -> void
+{
+    open(filename.c_str(), mode);
+}
+
+}
+
+#endif /* fstream_hpp */

--- a/library/include/flow/instance.hpp
+++ b/library/include/flow/instance.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "flow/channel.hpp"
+#include "flow/fstream.hpp"
 #include "flow/process_id.hpp"
 #include "flow/prototype_name.hpp"
 
@@ -13,11 +14,14 @@ namespace flow {
 
 struct instance {
     process_id id;
+    fstream diags;
     std::map<prototype_name, instance> children;
     std::vector<channel> channels;
 };
 
-std::ostream& operator<<(std::ostream& os, const instance& value);
+auto operator<<(std::ostream& os, const instance& value) -> std::ostream&;
+
+auto temporary_fstream() -> fstream;
 
 }
 

--- a/library/include/flow/io_type.hpp
+++ b/library/include/flow/io_type.hpp
@@ -7,6 +7,15 @@ namespace flow {
 
 enum class io_type: int { in = 0, out = 1};
 
+constexpr auto to_cstring(io_type direction) -> const char*
+{
+    switch (direction) {
+    case io_type::in: return "in";
+    case io_type::out: return "out";
+    }
+    return "";
+}
+
 int to_open_flags(io_type direction);
 
 std::ostream& operator<<(std::ostream& os, io_type value);

--- a/library/include/flow/prototype.hpp
+++ b/library/include/flow/prototype.hpp
@@ -14,12 +14,12 @@
 
 namespace flow {
 
-struct descriptor {
+struct descriptor_info {
     std::string comment;
     io_type direction;
 };
 
-using descriptor_container = std::map<descriptor_id, descriptor>;
+using descriptor_container = std::map<descriptor_id, descriptor_info>;
 
 inline const auto standard_descriptors = descriptor_container{
     {descriptor_id{0}, {"stdin", io_type::in}},

--- a/library/include/flow/utility.hpp
+++ b/library/include/flow/utility.hpp
@@ -2,11 +2,15 @@
 #define utility_hpp
 
 #include <map>
+#include <ostream>
 #include <span>
 #include <string>
 #include <vector>
 
 namespace flow {
+
+struct instance;
+struct prototype_name;
 
 /// @note This is NOT an "async-signal-safe" function. So, it's not suitable for forked child to call.
 /// @see https://man7.org/linux/man-pages/man7/signal-safety.7.html
@@ -21,6 +25,8 @@ std::vector<std::string> make_arg_bufs(const std::map<std::string, std::string>&
 /// @note This is NOT an "async-signal-safe" function. So, it's not suitable for forked child to call.
 /// @see https://man7.org/linux/man-pages/man7/signal-safety.7.html
 std::vector<char*> make_argv(const std::span<std::string>& args);
+
+void show_diags(const prototype_name& name, instance& object, std::ostream& os);
 
 }
 

--- a/library/source/flow/descriptor_iostream.cpp
+++ b/library/source/flow/descriptor_iostream.cpp
@@ -1,0 +1,46 @@
+#include <cstring> // for std::memmove
+#include <unistd.h> // for ::close
+
+#include "flow/descriptor_iostream.hpp"
+
+namespace flow {
+
+descriptor_streambuf::int_type descriptor_streambuf::underflow()
+{
+    if (gptr() < egptr()) {
+        return traits_type::to_int_type(*gptr());
+    }
+
+    const auto nputback = std::min(gptr() - eback(), putback_size);
+    std::memmove(buffer.data() + (putback_size - nputback),
+                 gptr() - nputback, nputback);
+    const auto nread = ::read(int(id), buffer.data() + putback_size, buffer.size());
+    if (nread == -1) {
+        return traits_type::eof();
+    }
+    setg(buffer.data() + (putback_size - nputback),
+         buffer.data() + putback_size,
+         buffer.data() + putback_size + nread);
+    return traits_type::to_int_type(*gptr());
+}
+
+descriptor_streambuf::int_type
+descriptor_streambuf::overflow(int_type c)
+{
+    if (!traits_type::eq_int_type(c, traits_type::eof()))
+    {
+        char_type onebuf = traits_type::to_char_type(c);
+        if (::write(int(id), &onebuf, sizeof(char_type)) != 1) {
+            return traits_type::eof();
+        }
+    }
+    return traits_type::not_eof(c);
+}
+
+std::streamsize
+descriptor_streambuf::xsputn(const char_type* s, std::streamsize n)
+{
+    return ::write(int(id), s, n);
+}
+
+}

--- a/library/source/flow/fstream.cpp
+++ b/library/source/flow/fstream.cpp
@@ -1,0 +1,5 @@
+#include "flow/fstream.hpp"
+
+namespace flow {
+
+}

--- a/library/source/flow/instance.cpp
+++ b/library/source/flow/instance.cpp
@@ -1,3 +1,5 @@
+#include <unistd.h> // for getpid
+
 #include "flow/instance.hpp"
 
 namespace flow {
@@ -27,6 +29,17 @@ std::ostream& operator<<(std::ostream& os, const instance& value)
     os << "}";
     os << "}";
     return os;
+}
+
+auto temporary_fstream() -> fstream
+{
+    // "w+xb"
+    constexpr auto mode =
+        fstream::in|fstream::out|fstream::trunc|fstream::binary|fstream::noreplace|fstream::tmpfile;
+
+    fstream stream;
+    stream.open(std::filesystem::temp_directory_path(), mode);
+    return stream;
 }
 
 }

--- a/library/source/flow/io_type.cpp
+++ b/library/source/flow/io_type.cpp
@@ -15,14 +15,7 @@ int to_open_flags(io_type direction)
 
 std::ostream& operator<<(std::ostream& os, io_type value)
 {
-    switch (value) {
-    case flow::io_type::in:
-        os << "in";
-        break;
-    case flow::io_type::out:
-        os << "out";
-        break;
-    }
+    os << to_cstring(value);
     return os;
 }
 

--- a/library/source/flow/utility.cpp
+++ b/library/source/flow/utility.cpp
@@ -1,3 +1,14 @@
+#include <cstddef> // for std::ptrdiff_t
+#include <cstdio> // for ::tmpfile, std::fclose
+#include <memory> // for std::unique_ptr
+#include <streambuf>
+#include <string> // for std::char_traits
+
+#include <stdlib.h> // for ::mkstemp
+#include <unistd.h> // for ::close
+
+#include "flow/descriptor_id.hpp"
+#include "flow/instance.hpp"
 #include "flow/utility.hpp"
 
 namespace flow {
@@ -37,6 +48,25 @@ std::vector<char*> make_argv(const std::span<std::string>& args)
     }
     result.push_back(nullptr); // last element must always be nullptr!
     return result;
+}
+
+void show_diags(const prototype_name& name, instance& object, std::ostream& os)
+{
+    if (object.diags.is_open()) {
+        object.diags.seekg(0, std::ios_base::end);
+        if (object.diags.tellg() != 0) {
+            object.diags.seekg(0, std::ios_base::beg);
+            os << "Diagnostics for " << name << "...\n";
+            // istream_iterator skips ws, so use istreambuf_iterator...
+            std::copy(std::istreambuf_iterator<char>(object.diags.rdbuf()),
+                      std::istreambuf_iterator<char>(),
+                      std::ostream_iterator<char>(os));
+        }
+    }
+    for (auto&& map_entry: object.children) {
+        const auto full_name = name.value + "." + map_entry.first.value;
+        show_diags(prototype_name{full_name}, map_entry.second, os);
+    }
 }
 
 }


### PR DESCRIPTION
Corralling the diagnostics was my original/primary intent.

Things spun out though with getting that to work within standard C++ stream I/O facilities. Standard C++ stream I/O facilities don't provide a direct interface for acquiring a stream for a temporary file, nor a FILE*, nor a POSIX file descriptor - at least not without using ancillary, insecure, or racy C interfaces. That's disappointing enough that I looked into proposing an update to the C++ standards.

I also considered using boost.iostreams. That's why it's now pulled in if found. I found those interfaces disappointing though too. For one, the boost stream class I tried didn't have support for move semantics. For another, it doesn't seem like that library has been maintained. One can work around classes without move support of course by passing those instances as pointers (via unique_ptr or whatever) but that just seems more unappealing to me.

Which is all to say, I'm more inclined to change the implementation for this than to go back on this intent.